### PR TITLE
Update __file__ and __line__ to #file and #line.

### DIFF
--- a/UITests/UITests.swift
+++ b/UITests/UITests.swift
@@ -26,7 +26,7 @@ class UITests: XCTestCase {
         waitForElementToAppear(postCountLabel)
     }
 
-    private func waitForElementToAppear(element: XCUIElement, file: String = __FILE__, line: UInt = __LINE__) {
+    private func waitForElementToAppear(element: XCUIElement, file: String = #file, line: UInt = #line) {
         let existsPredicate = NSPredicate(format: "exists == true")
         expectationForPredicate(existsPredicate, evaluatedWithObject: element, handler: nil)
 


### PR DESCRIPTION
Swift 2.2 is showing warnings suggesting this update to #file and #Line in preparation for **file** and **line**’s deprecation in Swift 3.0.

<img width="1280" alt="screen shot 2016-03-27 at 4 29 33 pm" src="https://cloud.githubusercontent.com/assets/1297027/14067757/13a07278-f43a-11e5-939f-d9bec1ee3f8c.png">
